### PR TITLE
Remove explicit promise wrapping from controller

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -31,10 +31,10 @@ class DefaultController
      */
     public function __invoke(Request $request)
     {
-        return new FulfilledPromise(
-            new JsonResponse([
+        return new JsonResponse(
+            [
                 'message' => 'DriftPHP is working!',
-            ], 200)
+            ], 200
         );
     }
 }


### PR DESCRIPTION
Currently, I'm playing around the demo and skeleton, trying to build something. I'm not sure if you did it on purpose to explicitly show that controllers return promises. But if under the hood the Kernel already does this job (wraps responses into promises) I think there is no need for this extra code. It makes the quick start even easier. 

What do you think?